### PR TITLE
Extend policy search

### DIFF
--- a/src/api/openAPI/apis/policy-api.ts
+++ b/src/api/openAPI/apis/policy-api.ts
@@ -22,6 +22,8 @@ import { DUMMY_BASE_URL, assertParamExists, setApiKeyToObject, setBasicAuthToObj
 // @ts-ignore
 import { BASE_PATH, COLLECTION_FORMATS, type RequestArgs, BaseAPI, RequiredError, operationServerMap } from '../base';
 // @ts-ignore
+import type { LocationResolution } from '../models';
+// @ts-ignore
 import type { MeasurementDto } from '../models';
 // @ts-ignore
 import type { MeasurementResolution } from '../models';
@@ -152,10 +154,11 @@ export const PolicyApiAxiosParamCreator = function (configuration?: Configuratio
          * 
          * @param {number} [maxPrice] 
          * @param {MeasurementResolution} [measurementResolution] 
+         * @param {LocationResolution} [locationResolution] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        searchPolicies: async (maxPrice?: number, measurementResolution?: MeasurementResolution, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+        searchPolicies: async (maxPrice?: number, measurementResolution?: MeasurementResolution, locationResolution?: LocationResolution, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
             const localVarPath = `/api/policies/search`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -177,6 +180,10 @@ export const PolicyApiAxiosParamCreator = function (configuration?: Configuratio
 
             if (measurementResolution !== undefined) {
                 localVarQueryParameter['measurementResolution'] = measurementResolution;
+            }
+
+            if (locationResolution !== undefined) {
+                localVarQueryParameter['locationResolution'] = locationResolution;
             }
 
 
@@ -240,11 +247,12 @@ export const PolicyApiFp = function(configuration?: Configuration) {
          * 
          * @param {number} [maxPrice] 
          * @param {MeasurementResolution} [measurementResolution] 
+         * @param {LocationResolution} [locationResolution] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async searchPolicies(maxPrice?: number, measurementResolution?: MeasurementResolution, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<PolicyDto>>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.searchPolicies(maxPrice, measurementResolution, options);
+        async searchPolicies(maxPrice?: number, measurementResolution?: MeasurementResolution, locationResolution?: LocationResolution, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<PolicyDto>>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.searchPolicies(maxPrice, measurementResolution, locationResolution, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['PolicyApi.searchPolicies']?.[localVarOperationServerIndex]?.url;
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
@@ -290,11 +298,12 @@ export const PolicyApiFactory = function (configuration?: Configuration, basePat
          * 
          * @param {number} [maxPrice] 
          * @param {MeasurementResolution} [measurementResolution] 
+         * @param {LocationResolution} [locationResolution] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        searchPolicies(maxPrice?: number, measurementResolution?: MeasurementResolution, options?: RawAxiosRequestConfig): AxiosPromise<Array<PolicyDto>> {
-            return localVarFp.searchPolicies(maxPrice, measurementResolution, options).then((request) => request(axios, basePath));
+        searchPolicies(maxPrice?: number, measurementResolution?: MeasurementResolution, locationResolution?: LocationResolution, options?: RawAxiosRequestConfig): AxiosPromise<Array<PolicyDto>> {
+            return localVarFp.searchPolicies(maxPrice, measurementResolution, locationResolution, options).then((request) => request(axios, basePath));
         },
     };
 };
@@ -343,12 +352,13 @@ export class PolicyApi extends BaseAPI {
      * 
      * @param {number} [maxPrice] 
      * @param {MeasurementResolution} [measurementResolution] 
+     * @param {LocationResolution} [locationResolution] 
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof PolicyApi
      */
-    public searchPolicies(maxPrice?: number, measurementResolution?: MeasurementResolution, options?: RawAxiosRequestConfig) {
-        return PolicyApiFp(this.configuration).searchPolicies(maxPrice, measurementResolution, options).then((request) => request(this.axios, this.basePath));
+    public searchPolicies(maxPrice?: number, measurementResolution?: MeasurementResolution, locationResolution?: LocationResolution, options?: RawAxiosRequestConfig) {
+        return PolicyApiFp(this.configuration).searchPolicies(maxPrice, measurementResolution, locationResolution, options).then((request) => request(this.axios, this.basePath));
     }
 }
 

--- a/src/hooks/services/usePolicyService.ts
+++ b/src/hooks/services/usePolicyService.ts
@@ -1,6 +1,12 @@
 import { useCallback, useContext } from 'react';
 import { ApiContext } from '../../provider/context/ApiContext.tsx';
-import { MeasurementResolution, PolicyCreateDto, PolicyDto, ProblemDetails } from '../../api/openAPI';
+import {
+    LocationResolution,
+    MeasurementResolution,
+    PolicyCreateDto,
+    PolicyDto,
+    ProblemDetails,
+} from '../../api/openAPI';
 import { AxiosError } from 'axios';
 
 export const usePolicyService = () => {
@@ -41,9 +47,13 @@ export const usePolicyService = () => {
     );
 
     const searchPolicies = useCallback(
-        async (maxPrice?: number, measurementResolution?: MeasurementResolution): Promise<PolicyDto[]> => {
+        async (
+            maxPrice?: number,
+            measurementResolution?: MeasurementResolution,
+            locationResolution?: LocationResolution
+        ): Promise<PolicyDto[]> => {
             try {
-                const response = await policyApi.searchPolicies(maxPrice, measurementResolution);
+                const response = await policyApi.searchPolicies(maxPrice, measurementResolution, locationResolution);
                 return response.data;
             } catch (error) {
                 const axiosError = error as AxiosError<ProblemDetails>;

--- a/src/pages/navbar/PolicySearchPage.tsx
+++ b/src/pages/navbar/PolicySearchPage.tsx
@@ -1,6 +1,6 @@
 import { PageContainer } from '@toolpad/core/PageContainer';
 import React, { useEffect, useState } from 'react';
-import { MeasurementResolution, PolicyDto } from '../../api/openAPI';
+import { LocationResolution, MeasurementResolution, PolicyDto } from '../../api/openAPI';
 import { usePolicyService } from '../../hooks/services/usePolicyService.ts';
 import {
     Box,
@@ -25,9 +25,13 @@ const PolicySearchPage = () => {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
-    const loadPolicies = async (maxPrice?: number, measurementResolution?: MeasurementResolution) => {
+    const loadPolicies = async (
+        maxPrice?: number,
+        measurementResolution?: MeasurementResolution,
+        locationResolution?: LocationResolution
+    ) => {
         try {
-            const policies = await searchPolicies(maxPrice, measurementResolution);
+            const policies = await searchPolicies(maxPrice, measurementResolution, locationResolution);
             setPolicies(policies);
         } catch (error) {
             console.error(error);
@@ -40,6 +44,7 @@ const PolicySearchPage = () => {
         const data = new FormData(event.currentTarget);
         let measurementResolution = data.get('measurementResolution') as MeasurementResolution | undefined;
         let price = data.get('price') as unknown as number | undefined;
+        let locationResolution = data.get('locationResolution') as LocationResolution | undefined;
 
         if (!measurementResolution) {
             measurementResolution = undefined;
@@ -49,7 +54,11 @@ const PolicySearchPage = () => {
             price = undefined;
         }
 
-        void loadPolicies(price, measurementResolution);
+        if (!locationResolution) {
+            locationResolution = undefined;
+        }
+
+        void loadPolicies(price, measurementResolution, locationResolution);
     };
 
     const handleReset = () => {
@@ -85,6 +94,30 @@ const PolicySearchPage = () => {
                             </option>
                             <option aria-label="Week" value={MeasurementResolution.Week}>
                                 Week
+                            </option>
+                        </NativeSelect>
+                    </FormControl>
+                    <FormControl>
+                        <FormLabel htmlFor="locationResolution">Location Resolution</FormLabel>
+                        <NativeSelect id="locationResolution" name="locationResolution">
+                            <option></option>
+                            <option aria-label="None" value={LocationResolution.None}>
+                                None
+                            </option>
+                            <option aria-label="Street Name" value={LocationResolution.StreetName}>
+                                Street Name
+                            </option>
+                            <option aria-label="City" value={LocationResolution.City}>
+                                City
+                            </option>
+                            <option aria-label="State" value={LocationResolution.State}>
+                                State
+                            </option>
+                            <option aria-label="Country" value={LocationResolution.Country}>
+                                Country
+                            </option>
+                            <option aria-label="Continent" value={LocationResolution.Continent}>
+                                Continent
                             </option>
                         </NativeSelect>
                     </FormControl>


### PR DESCRIPTION
This pull request introduces the `LocationResolution` parameter to the `searchPolicies` function across various parts of the codebase. The changes ensure that the `LocationResolution` parameter is properly integrated into the API calls, hooks, and UI components.

Key changes include:

### API Integration:

* Added `LocationResolution` import and parameter to the `searchPolicies` function in `src/api/openAPI/apis/policy-api.ts`. This affects multiple functions and ensures that the `LocationResolution` is included in the API requests. [[1]](diffhunk://#diff-f29287179bb313986a5cc255c4987503cbad31f17bbf82e23eda56d600e84d79R25-R26) [[2]](diffhunk://#diff-f29287179bb313986a5cc255c4987503cbad31f17bbf82e23eda56d600e84d79R157-R161) [[3]](diffhunk://#diff-f29287179bb313986a5cc255c4987503cbad31f17bbf82e23eda56d600e84d79R185-R188) [[4]](diffhunk://#diff-f29287179bb313986a5cc255c4987503cbad31f17bbf82e23eda56d600e84d79R250-R255) [[5]](diffhunk://#diff-f29287179bb313986a5cc255c4987503cbad31f17bbf82e23eda56d600e84d79R301-R306) [[6]](diffhunk://#diff-f29287179bb313986a5cc255c4987503cbad31f17bbf82e23eda56d600e84d79R355-R361)

### Hooks Update:

* Updated `usePolicyService` hook to include `LocationResolution` in the `searchPolicies` function. This allows the hook to handle the new parameter and pass it to the API calls. [[1]](diffhunk://#diff-4e68234a9844712f9529a999d051c8853175f5512249c3e36fff67479fef020bL3-R9) [[2]](diffhunk://#diff-4e68234a9844712f9529a999d051c8853175f5512249c3e36fff67479fef020bL44-R56)

### UI Components:

* Modified `PolicySearchPage` to include a new form control for `LocationResolution`, ensuring that users can specify this parameter when searching for policies. This includes changes to the form handling and the `loadPolicies` function. [[1]](diffhunk://#diff-413103428fd33abbb191ee3177693312e1266594c3062f553cdf1301c2a68f69L3-R3) [[2]](diffhunk://#diff-413103428fd33abbb191ee3177693312e1266594c3062f553cdf1301c2a68f69L28-R34) [[3]](diffhunk://#diff-413103428fd33abbb191ee3177693312e1266594c3062f553cdf1301c2a68f69R47) [[4]](diffhunk://#diff-413103428fd33abbb191ee3177693312e1266594c3062f553cdf1301c2a68f69L52-R61) [[5]](diffhunk://#diff-413103428fd33abbb191ee3177693312e1266594c3062f553cdf1301c2a68f69R100-R123)